### PR TITLE
Add federal ingestion toolkit for Congress.gov and GovInfo

### DIFF
--- a/DIFF_20251102_033600.md
+++ b/DIFF_20251102_033600.md
@@ -1,0 +1,7 @@
+# Change Log 20251102_033600
+
+- Created `tools/federal_ingest/` package with clients, normalization helpers, storage utilities, and CLIs to orchestrate ingestion from Congress.gov and GovInfo (REST and bulkdata).
+- Added SQLAlchemy table mapping for bulk resources and database helpers to perform upserts grouped by table, mirroring existing ingestion structure.
+- Implemented JSON export and optional download support, including normalized record serialization with ISO timestamps.
+- Documented setup, authentication requirements, and usage scenarios in `tools/federal_ingest/README.md`.
+- Declared new dependencies (`sqlalchemy`, `tenacity`) required for the ingestion workflow in tooling manifests.

--- a/RECOMMENDATIONS_20251102_033612.md
+++ b/RECOMMENDATIONS_20251102_033612.md
@@ -1,0 +1,5 @@
+# Recommendations 20251102_033612
+
+- Integrate the new `tools/federal_ingest` CLI entrypoints with existing orchestration scripts (e.g., `manage_all_ingestion.py`) to ensure federal data jobs are scheduled consistently with state-level imports.
+- Add unit tests that exercise the normalization helpers against recorded API fixtures to prevent schema regressions as upstream providers evolve.
+- Consider caching or checkpointing bulkdata crawl state (e.g., storing last-seen resource keys) to avoid repeatedly traversing large directory trees during scheduled runs.

--- a/tools/federal_ingest/README.md
+++ b/tools/federal_ingest/README.md
@@ -1,0 +1,138 @@
+# Federal Ingestion Toolkit
+
+This package bundles lightweight API clients and command-line utilities for
+collecting federal legislative data from three upstream sources:
+
+* [`api.congress.gov`](https://api.congress.gov) (bills, members, votes)
+* [`api.govinfo.gov`](https://api.govinfo.gov) (package metadata and downloads)
+* [`govinfo.gov/bulkdata`](https://www.govinfo.gov/bulkdata) (bulk ZIP/XML resources)
+
+The folder mirrors the layout of the legacy `govdata_ingest` utilities and provides
+consistent helpers for exporting normalized JSON, optionally downloading assets, and
+upserting the results into PostgreSQL.
+
+## Environment setup
+
+1. **Python dependencies** – ensure the shared tooling environment is installed:
+
+   ```bash
+   pip install -r tools/requirements.txt
+   ```
+
+   The new scripts rely on `requests`, `pydantic`, `sqlalchemy`, `tenacity`, and
+   `beautifulsoup4`. These libraries are declared in `tools/requirements.txt` and
+   `tools/pyproject.toml`.
+
+2. **API credentials** – configure the required environment variables. You can keep
+   them in a root-level `.env` file and load it with your preferred tooling (for
+   example `dotenv`, `direnv`, or `set -a; source .env`), or export the values
+   directly in your shell session before running the CLI.
+
+   ```bash
+   export CONGRESS_GOV_API_KEY="your-congress-api-key"
+   export GOVINFO_API_KEY="your-govinfo-api-key"
+   # Optional: overrides psycopg2/sqlalchemy connection target
+   export FEDERAL_INGEST_DATABASE_URL="postgresql://user:pass@host:5432/database"
+   ```
+
+   The `CONGRESS_GOV_API_KEY` and `GOVINFO_API_KEY` values are required for REST calls.
+
+3. **Database connectivity** – by default the scripts reuse `tools/db_config.py` to
+   build the PostgreSQL connection string. Override the target with
+   `FEDERAL_INGEST_DATABASE_URL` when needed.
+
+## Database schema
+
+Normalized records are written into existing ingestion tables defined in
+`tools/data_pipeline/scripts/schema.py`. Bulk resource metadata is persisted in a new
+`govinfo_bulk_resources` table. Create it manually before running upserts:
+
+```sql
+CREATE TABLE IF NOT EXISTS public.govinfo_bulk_resources (
+    resource_key TEXT PRIMARY KEY,
+    collection TEXT NOT NULL,
+    congress TEXT NULL,
+    resource_path TEXT NOT NULL,
+    download_url TEXT NOT NULL,
+    retrieved_at TIMESTAMPTZ NOT NULL,
+    raw_payload JSONB NOT NULL
+);
+```
+
+Ensure the database user has permission to insert into these tables.
+
+## Command-line usage
+
+All commands are routed through a unified entrypoint:
+
+```bash
+python -m tools.federal_ingest.cli.main <source> [options]
+```
+
+Available sources and representative invocations:
+
+### Congress.gov REST API
+
+Fetch bills and export them to disk, while also writing into PostgreSQL:
+
+```bash
+python -m tools.federal_ingest.cli.main congress bills \
+  --congress 118 \
+  --limit 100 \
+  --export data/congress_bills.jsonl \
+  --upsert
+```
+
+List Senate members without persistence (stdout logging only):
+
+```bash
+python -m tools.federal_ingest.cli.main congress members \
+  --congress 118 \
+  --chamber senate
+```
+
+### GovInfo REST API
+
+Store package metadata for the `BILLS` collection:
+
+```bash
+python -m tools.federal_ingest.cli.main govinfo-api packages \
+  --collection BILLS \
+  --export data/govinfo_packages.jsonl
+```
+
+Download metadata for all artifacts in a package and upsert them:
+
+```bash
+python -m tools.federal_ingest.cli.main govinfo-api downloads \
+  --package-id BILLS-118hr1 \
+  --upsert
+```
+
+### GovInfo bulk data
+
+Enumerate all available resources for the 118th Congress `BILLSTATUS` collection,
+write the manifest to disk, download the ZIP/XML payloads, and upsert metadata:
+
+```bash
+python -m tools.federal_ingest.cli.main govinfo-bulk \
+  --collection BILLSTATUS \
+  --congress 118 \
+  --export data/govinfo_bulk_status.jsonl \
+  --download-dir downloads/billstatus \
+  --upsert
+```
+
+Downloads are optional—omit `--download-dir` to only capture metadata.
+
+## Configuration hooks
+
+* The clients reuse the retry-aware HTTP session provided by `tools/data_pipeline`.
+* Normalized records store source payloads under the `raw_payload` key, enabling audit
+  trails.
+* CLI utilities honor `--database-url` to override the connection string on a per-run
+  basis.
+
+For automation, invoke these scripts from cron or orchestrators using the same flags
+shown above. The normalized JSONL exports provide reproducible manifests that can be
+archived alongside the raw downloads.

--- a/tools/federal_ingest/__init__.py
+++ b/tools/federal_ingest/__init__.py
@@ -1,0 +1,5 @@
+"""Federal ingestion utilities for Congress.gov and GovInfo."""
+
+from .cli.main import main
+
+__all__ = ["main"]

--- a/tools/federal_ingest/cli/__init__.py
+++ b/tools/federal_ingest/cli/__init__.py
@@ -1,0 +1,5 @@
+"""CLI entrypoints for federal ingestion."""
+
+from .main import main
+
+__all__ = ["main"]

--- a/tools/federal_ingest/cli/common.py
+++ b/tools/federal_ingest/cli/common.py
@@ -1,0 +1,42 @@
+"""Shared CLI helpers for federal ingestion scripts."""
+from __future__ import annotations
+
+import logging
+from pathlib import Path
+from typing import Iterable, List, Optional
+
+from ..db import create_db_engine, session_scope, upsert_normalized_records
+from ..normalization import NormalizedRecord
+from ..storage import export_records
+
+logger = logging.getLogger(__name__)
+
+
+def configure_logging(verbose: bool) -> None:
+    level = logging.DEBUG if verbose else logging.INFO
+    logging.basicConfig(level=level, format="%(asctime)s [%(levelname)s] %(name)s: %(message)s")
+
+
+def handle_records(
+    records: Iterable[NormalizedRecord],
+    *,
+    export_path: Optional[Path] = None,
+    upsert: bool = False,
+    database_url: Optional[str] = None,
+) -> List[NormalizedRecord]:
+    """Materialize records and optionally export or persist them."""
+
+    record_list = list(records)
+    logger.debug("Materialized %s records", len(record_list))
+    if export_path:
+        export_records(export_path, record_list)
+    if upsert and record_list:
+        engine = create_db_engine(database_url)
+        with session_scope(engine) as session:
+            upsert_results = upsert_normalized_records(session, record_list)
+            for table_name, count in upsert_results.items():
+                logger.info("Upserted %s rows into %s", count, table_name)
+    return record_list
+
+
+__all__ = ["configure_logging", "handle_records"]

--- a/tools/federal_ingest/cli/congress_cli.py
+++ b/tools/federal_ingest/cli/congress_cli.py
@@ -1,0 +1,53 @@
+"""Command line interface for Congress.gov ingestion."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ..clients import CongressGovIngestClient
+from ..cli.common import configure_logging, handle_records
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Ingest data from api.congress.gov")
+    parser.add_argument("command", choices=["bills", "members", "votes"], help="Resource to fetch")
+    parser.add_argument("--congress", default="118", help="Congress number (e.g., 118)")
+    parser.add_argument("--chamber", help="Legislative chamber for member/vote endpoints")
+    parser.add_argument("--limit", type=int, default=250, help="Maximum records per request")
+    parser.add_argument("--export", type=Path, help="Optional JSONL export path")
+    parser.add_argument("--upsert", action="store_true", help="Persist results into PostgreSQL")
+    parser.add_argument(
+        "--database-url",
+        help="Override database connection string (defaults to FEDERAL_INGEST_DATABASE_URL or db_config)",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.verbose)
+
+    with CongressGovIngestClient() as client:
+        if args.command == "bills":
+            records = client.iter_bills(congress=args.congress, limit=args.limit)
+        elif args.command == "members":
+            if not args.chamber:
+                parser.error("--chamber is required for members")
+            records = client.iter_members(congress=args.congress, chamber=args.chamber, limit=args.limit)
+        else:
+            if not args.chamber:
+                parser.error("--chamber is required for votes")
+            records = client.iter_votes(congress=args.congress, chamber=args.chamber, limit=args.limit)
+
+        handle_records(
+            records,
+            export_path=args.export,
+            upsert=args.upsert,
+            database_url=args.database_url,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/federal_ingest/cli/govinfo_api_cli.py
+++ b/tools/federal_ingest/cli/govinfo_api_cli.py
@@ -1,0 +1,51 @@
+"""Command line interface for GovInfo REST API ingestion."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+
+from ..clients import GovInfoApiIngestClient
+from ..cli.common import configure_logging, handle_records
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Ingest data from api.govinfo.gov")
+    parser.add_argument("command", choices=["packages", "downloads"], help="Resource to fetch")
+    parser.add_argument("--collection", help="GovInfo collection code for package listing")
+    parser.add_argument("--package-id", help="Package identifier for downloads")
+    parser.add_argument("--page-size", type=int, default=100, help="Number of items to request per page")
+    parser.add_argument("--export", type=Path, help="Optional JSONL export path")
+    parser.add_argument("--upsert", action="store_true", help="Persist results into PostgreSQL")
+    parser.add_argument(
+        "--database-url",
+        help="Override database connection string (defaults to FEDERAL_INGEST_DATABASE_URL or db_config)",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.verbose)
+
+    with GovInfoApiIngestClient() as client:
+        if args.command == "packages":
+            if not args.collection:
+                parser.error("--collection is required for package listing")
+            records = client.iter_packages(collection=args.collection, page_size=args.page_size)
+        else:
+            if not args.package_id:
+                parser.error("--package-id is required for downloads")
+            records = client.iter_downloads(args.package_id)
+
+        handle_records(
+            records,
+            export_path=args.export,
+            upsert=args.upsert,
+            database_url=args.database_url,
+        )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/federal_ingest/cli/govinfo_bulk_cli.py
+++ b/tools/federal_ingest/cli/govinfo_bulk_cli.py
@@ -1,0 +1,53 @@
+"""Command line interface for GovInfo bulk data ingestion."""
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import List
+
+from ..cli.common import configure_logging, handle_records
+from ..clients import GovInfoBulkClient
+from ..normalization import NormalizedRecord
+from ..storage import download_resource
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Crawl bulkdata.govinfo.gov resources")
+    parser.add_argument("--collection", required=True, help="GovInfo collection code (e.g., BILLS, BILLSTATUS)")
+    parser.add_argument("--congress", help="Optional congress filter (e.g., 118)")
+    parser.add_argument("--export", type=Path, help="Optional JSONL export path")
+    parser.add_argument("--download-dir", type=Path, help="Directory to download bulk resources")
+    parser.add_argument("--upsert", action="store_true", help="Persist results into PostgreSQL")
+    parser.add_argument(
+        "--database-url",
+        help="Override database connection string (defaults to FEDERAL_INGEST_DATABASE_URL or db_config)",
+    )
+    parser.add_argument("--verbose", action="store_true", help="Enable debug logging")
+    return parser
+
+
+def main(argv: list[str] | None = None) -> None:
+    parser = build_parser()
+    args = parser.parse_args(argv)
+    configure_logging(args.verbose)
+
+    with GovInfoBulkClient() as client:
+        records_iter = client.iter_resources(collection=args.collection, congress=args.congress)
+        records: List[NormalizedRecord] = list(records_iter)
+
+    if args.download_dir:
+        for record in records:
+            url = record["data"].get("download_url")
+            if url:
+                download_resource(url, args.download_dir)
+
+    handle_records(
+        records,
+        export_path=args.export,
+        upsert=args.upsert,
+        database_url=args.database_url,
+    )
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/federal_ingest/cli/main.py
+++ b/tools/federal_ingest/cli/main.py
@@ -1,0 +1,38 @@
+"""Unified entrypoint for federal ingestion CLIs."""
+from __future__ import annotations
+
+import argparse
+from typing import List
+
+from . import congress_cli, govinfo_api_cli, govinfo_bulk_cli
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(description="Federal ingestion toolkit")
+    parser.add_argument(
+        "source",
+        choices=["congress", "govinfo-api", "govinfo-bulk"],
+        help="Which upstream source to interact with",
+    )
+    parser.add_argument(
+        "args",
+        nargs=argparse.REMAINDER,
+        help="Arguments forwarded to the specific source CLI",
+    )
+    return parser
+
+
+def main(argv: List[str] | None = None) -> None:
+    parser = build_parser()
+    parsed = parser.parse_args(argv)
+    remaining = parsed.args
+    if parsed.source == "congress":
+        congress_cli.main(remaining)
+    elif parsed.source == "govinfo-api":
+        govinfo_api_cli.main(remaining)
+    else:
+        govinfo_bulk_cli.main(remaining)
+
+
+if __name__ == "__main__":
+    main()

--- a/tools/federal_ingest/clients/__init__.py
+++ b/tools/federal_ingest/clients/__init__.py
@@ -1,0 +1,11 @@
+"""Client factories for federal ingestion."""
+
+from .congress import CongressGovIngestClient
+from .govinfo_api import GovInfoApiIngestClient
+from .govinfo_bulk import GovInfoBulkClient
+
+__all__ = [
+    "CongressGovIngestClient",
+    "GovInfoApiIngestClient",
+    "GovInfoBulkClient",
+]

--- a/tools/federal_ingest/clients/congress.py
+++ b/tools/federal_ingest/clients/congress.py
@@ -1,0 +1,60 @@
+"""Congress.gov REST API ingestion client with normalization helpers."""
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+from tools.data_pipeline.clients.congress import CongressGovClient as _BaseCongressGovClient
+from tools.data_pipeline.models import CongressBill, CongressMember, CongressVote
+
+from ..normalization import (
+    congress_bill_to_record,
+    congress_member_to_record,
+    congress_vote_to_record,
+    NormalizedRecord,
+)
+
+
+class CongressGovIngestClient(_BaseCongressGovClient):
+    """Extend the shared Congress.gov client with normalized iterators."""
+
+    def iter_bills(
+        self,
+        *,
+        congress: str,
+        limit: int = 250,
+        normalized: bool = True,
+    ) -> Iterator[NormalizedRecord | CongressBill]:
+        bills: Iterable[CongressBill] = super().list_bills(congress=congress, limit=limit)
+        for bill in bills:
+            yield congress_bill_to_record(bill) if normalized else bill
+
+    def iter_members(
+        self,
+        *,
+        congress: str,
+        chamber: str,
+        limit: int = 250,
+        normalized: bool = True,
+    ) -> Iterator[NormalizedRecord | CongressMember]:
+        members: Iterable[CongressMember] = super().list_members(
+            congress=congress, chamber=chamber, limit=limit
+        )
+        for member in members:
+            yield congress_member_to_record(member) if normalized else member
+
+    def iter_votes(
+        self,
+        *,
+        congress: str,
+        chamber: str,
+        limit: int = 250,
+        normalized: bool = True,
+    ) -> Iterator[NormalizedRecord | CongressVote]:
+        votes: Iterable[CongressVote] = super().list_votes(
+            congress=congress, chamber=chamber, limit=limit
+        )
+        for vote in votes:
+            yield congress_vote_to_record(vote) if normalized else vote
+
+
+__all__ = ["CongressGovIngestClient"]

--- a/tools/federal_ingest/clients/govinfo_api.py
+++ b/tools/federal_ingest/clients/govinfo_api.py
@@ -1,0 +1,41 @@
+"""GovInfo REST API ingestion client with normalization helpers."""
+from __future__ import annotations
+
+from typing import Iterable, Iterator
+
+from tools.data_pipeline.clients.govinfo import GovInfoClient as _BaseGovInfoClient
+from tools.data_pipeline.models import GovInfoDownload, GovInfoPackage
+
+from ..normalization import (
+    govinfo_download_to_record,
+    govinfo_package_to_record,
+    NormalizedRecord,
+)
+
+
+class GovInfoApiIngestClient(_BaseGovInfoClient):
+    """High-level client exposing normalized package and download streams."""
+
+    def iter_packages(
+        self,
+        *,
+        collection: str,
+        page_size: int = 100,
+        normalized: bool = True,
+    ) -> Iterator[NormalizedRecord | GovInfoPackage]:
+        packages: Iterable[GovInfoPackage] = super().list_packages(collection=collection, page_size=page_size)
+        for package in packages:
+            yield govinfo_package_to_record(package) if normalized else package
+
+    def iter_downloads(
+        self,
+        package_id: str,
+        *,
+        normalized: bool = True,
+    ) -> Iterator[NormalizedRecord | GovInfoDownload]:
+        downloads: Iterable[GovInfoDownload] = super().list_downloads(package_id)
+        for download in downloads:
+            yield govinfo_download_to_record(download) if normalized else download
+
+
+__all__ = ["GovInfoApiIngestClient"]

--- a/tools/federal_ingest/clients/govinfo_bulk.py
+++ b/tools/federal_ingest/clients/govinfo_bulk.py
@@ -1,0 +1,112 @@
+"""GovInfo bulkdata directory crawler."""
+from __future__ import annotations
+
+import logging
+import os
+from dataclasses import dataclass
+from typing import Iterable, Iterator, List, Optional
+from urllib.parse import urljoin, urlparse
+
+import requests
+from bs4 import BeautifulSoup
+
+from ..normalization import NormalizedRecord, govinfo_bulk_resource_to_record
+
+logger = logging.getLogger(__name__)
+
+BULK_BASE_URL = "https://www.govinfo.gov/bulkdata"
+USER_AGENT = "OpenLegislationFederalIngest/1.0 (+https://github.com/nysenate/OpenLegislation)"
+
+
+@dataclass
+class BulkResource:
+    """Metadata describing a GovInfo bulk data resource."""
+
+    url: str
+    collection: str
+    congress: Optional[str]
+    resource_path: str
+
+
+class GovInfoBulkClient:
+    """Crawl bulkdata directory listings and yield normalized records."""
+
+    def __init__(self, *, session: Optional[requests.Session] = None) -> None:
+        self.session = session or requests.Session()
+        self.session.headers.setdefault("User-Agent", USER_AGENT)
+
+    def close(self) -> None:
+        self.session.close()
+
+    def __enter__(self) -> "GovInfoBulkClient":
+        return self
+
+    def __exit__(self, exc_type, exc, tb) -> None:  # type: ignore[override]
+        self.close()
+
+    def _fetch_listing(self, url: str) -> List[str]:
+        logger.debug("Fetching bulk listing %s", url)
+        response = self.session.get(url, timeout=30)
+        response.raise_for_status()
+        soup = BeautifulSoup(response.text, "html.parser")
+        return [link.get("href") for link in soup.select("a[href]")]
+
+    def _iter_resources(
+        self,
+        base_url: str,
+        *,
+        collection: str,
+        congress: Optional[str],
+        prefix: str = "",
+    ) -> Iterable[BulkResource]:
+        listing = self._fetch_listing(base_url)
+        for href in listing:
+            if not href or href in {"../", "?"}:
+                continue
+            absolute = urljoin(base_url, href)
+            if href.endswith("/"):
+                # Recurse into sub-directory
+                yield from self._iter_resources(
+                    absolute,
+                    collection=collection,
+                    congress=congress,
+                    prefix=os.path.join(prefix, href.strip("/")),
+                )
+                continue
+            if not href.lower().endswith(('.xml', '.zip', '.json', '.csv', '.txt')):
+                continue
+            resource_path = os.path.join(prefix, os.path.basename(urlparse(absolute).path))
+            yield BulkResource(
+                url=absolute,
+                collection=collection,
+                congress=congress,
+                resource_path=resource_path,
+            )
+
+    def iter_resources(
+        self,
+        *,
+        collection: str,
+        congress: Optional[str] = None,
+        normalized: bool = True,
+    ) -> Iterator[NormalizedRecord | BulkResource]:
+        target_url = BULK_BASE_URL.rstrip("/") + f"/{collection}"
+        if congress:
+            target_url += f"/{congress}"
+        if not target_url.endswith("/"):
+            target_url += "/"
+        resources = self._iter_resources(
+            target_url,
+            collection=collection,
+            congress=congress,
+            prefix="",
+        )
+        for resource in resources:
+            yield (
+                govinfo_bulk_resource_to_record(resource)
+                if normalized
+                else resource
+            )
+
+
+__all__ = ["GovInfoBulkClient", "BulkResource"]

--- a/tools/federal_ingest/config.py
+++ b/tools/federal_ingest/config.py
@@ -1,0 +1,37 @@
+"""Configuration helpers for federal ingestion pipelines."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+from functools import lru_cache
+from typing import Optional
+
+
+@dataclass(frozen=True)
+class FederalIngestSettings:
+    """Settings loaded from environment for API access and database targets."""
+
+    congress_api_key: str
+    govinfo_api_key: str
+    database_url: Optional[str]
+
+
+def _require_env(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(f"Missing required environment variable: {name}")
+    return value
+
+
+@lru_cache()
+def get_settings() -> FederalIngestSettings:
+    """Return cached settings instance."""
+
+    return FederalIngestSettings(
+        congress_api_key=_require_env("CONGRESS_GOV_API_KEY"),
+        govinfo_api_key=_require_env("GOVINFO_API_KEY"),
+        database_url=os.getenv("FEDERAL_INGEST_DATABASE_URL"),
+    )
+
+
+__all__ = ["FederalIngestSettings", "get_settings"]

--- a/tools/federal_ingest/db.py
+++ b/tools/federal_ingest/db.py
@@ -1,0 +1,67 @@
+"""Database helpers for federal ingestion pipelines."""
+from __future__ import annotations
+
+from collections import defaultdict
+from contextlib import contextmanager
+from typing import Dict, Iterable, Iterator, List, Sequence
+
+from sqlalchemy import create_engine
+from sqlalchemy.dialects.postgresql import insert
+from sqlalchemy.engine import Engine
+from sqlalchemy.orm import Session, sessionmaker
+
+from tools.db_config import get_connection_string
+
+from .config import get_settings
+from .normalization import NormalizedRecord
+from .schema import TABLE_MAP
+
+
+def create_db_engine(override_url: str | None = None) -> Engine:
+    settings = get_settings()
+    url = override_url or settings.database_url or get_connection_string()
+    return create_engine(url, future=True)
+
+
+@contextmanager
+def session_scope(engine: Engine) -> Iterator[Session]:
+    SessionLocal = sessionmaker(bind=engine, autoflush=False, autocommit=False, future=True)
+    session = SessionLocal()
+    try:
+        yield session
+        session.commit()
+    except Exception:
+        session.rollback()
+        raise
+    finally:
+        session.close()
+
+
+def upsert_normalized_records(session: Session, records: Iterable[NormalizedRecord]) -> Dict[str, int]:
+    grouped: Dict[str, List[Dict]] = defaultdict(list)
+    unique_columns: Dict[str, Sequence[str]] = {}
+    for record in records:
+        table_name = record["table"]
+        grouped[table_name].append(record["data"])
+        unique_columns.setdefault(table_name, record["unique_columns"])
+
+    results: Dict[str, int] = {}
+    for table_name, rows in grouped.items():
+        table = TABLE_MAP.get(table_name)
+        if table is None:
+            raise KeyError(f"Unknown table {table_name}")
+        stmt = insert(table).values(rows)
+        first = rows[0]
+        uniques = unique_columns[table_name]
+        update_cols = {
+            column: getattr(stmt.excluded, column)
+            for column in first.keys()
+            if column not in uniques
+        }
+        on_conflict_stmt = stmt.on_conflict_do_update(index_elements=list(uniques), set_=update_cols)
+        session.execute(on_conflict_stmt)
+        results[table_name] = len(rows)
+    return results
+
+
+__all__ = ["create_db_engine", "session_scope", "upsert_normalized_records"]

--- a/tools/federal_ingest/normalization.py
+++ b/tools/federal_ingest/normalization.py
@@ -1,0 +1,132 @@
+"""Utilities for converting API payloads to normalized database-friendly records."""
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import TYPE_CHECKING, Any, Dict, Mapping, Sequence, TypedDict
+
+from tools.data_pipeline.models import (
+    CongressBill,
+    CongressMember,
+    CongressVote,
+    GovInfoDownload,
+    GovInfoPackage,
+)
+
+if TYPE_CHECKING:
+    from .clients.govinfo_bulk import BulkResource
+
+
+class NormalizedRecord(TypedDict):
+    table: str
+    unique_columns: Sequence[str]
+    data: Dict[str, Any]
+
+
+def _serialize_datetime(value: datetime | date | None) -> str | None:
+    if value is None:
+        return None
+    if isinstance(value, datetime):
+        return value.replace(tzinfo=None).isoformat() + "Z"
+    return datetime.combine(value, datetime.min.time()).isoformat() + "Z"
+
+
+def _normalize_value(value: Any) -> Any:
+    if isinstance(value, (datetime, date)):
+        return _serialize_datetime(value)
+    if isinstance(value, list):
+        return [_normalize_value(item) for item in value]
+    if isinstance(value, set):
+        return [_normalize_value(item) for item in sorted(value)]
+    if isinstance(value, Mapping):
+        return {key: _normalize_value(val) for key, val in value.items()}
+    return value
+
+
+def _normalize_payload(raw: Mapping[str, Any]) -> Dict[str, Any]:
+    return {key: _normalize_value(value) for key, value in raw.items()}
+
+
+def congress_bill_to_record(bill: CongressBill) -> NormalizedRecord:
+    payload = bill.dict(exclude_none=True)
+    payload.setdefault("bill_id", bill.bill_id)
+    return NormalizedRecord(
+        table="congress_bills",
+        unique_columns=["bill_id"],
+        data=_normalize_payload(payload),
+    )
+
+
+def congress_member_to_record(member: CongressMember) -> NormalizedRecord:
+    payload = member.dict(exclude_none=True)
+    return NormalizedRecord(
+        table="congress_members",
+        unique_columns=["bioguide_id"],
+        data=_normalize_payload(payload),
+    )
+
+
+def congress_vote_to_record(vote: CongressVote) -> NormalizedRecord:
+    payload = vote.dict(exclude_none=True)
+    payload.setdefault(
+        "id",
+        f"{vote.chamber}-{vote.congress}-{vote.session or '1'}-{vote.roll_call}",
+    )
+    return NormalizedRecord(
+        table="congress_votes",
+        unique_columns=["id"],
+        data=_normalize_payload(payload),
+    )
+
+
+def govinfo_package_to_record(package: GovInfoPackage) -> NormalizedRecord:
+    payload = package.dict(exclude_none=True)
+    return NormalizedRecord(
+        table="govinfo_packages",
+        unique_columns=["package_id"],
+        data=_normalize_payload(payload),
+    )
+
+
+def govinfo_download_to_record(download: GovInfoDownload) -> NormalizedRecord:
+    payload = download.dict(exclude_none=True)
+    return NormalizedRecord(
+        table="govinfo_downloads",
+        unique_columns=["package_id", "format"],
+        data=_normalize_payload(payload),
+    )
+
+
+def govinfo_bulk_resource_to_record(resource: "BulkResource") -> NormalizedRecord:
+    resource_key = ":".join(
+        part for part in [resource.collection, resource.congress or "", resource.resource_path] if part
+    )
+    payload = {
+        "resource_key": resource_key,
+        "collection": resource.collection,
+        "congress": resource.congress,
+        "resource_path": resource.resource_path,
+        "download_url": resource.url,
+        "retrieved_at": datetime.utcnow(),
+        "raw_payload": {
+            "url": resource.url,
+            "collection": resource.collection,
+            "congress": resource.congress,
+            "resource_path": resource.resource_path,
+        },
+    }
+    return NormalizedRecord(
+        table="govinfo_bulk_resources",
+        unique_columns=["resource_key"],
+        data=_normalize_payload(payload),
+    )
+
+
+__all__ = [
+    "NormalizedRecord",
+    "congress_bill_to_record",
+    "congress_member_to_record",
+    "congress_vote_to_record",
+    "govinfo_package_to_record",
+    "govinfo_download_to_record",
+    "govinfo_bulk_resource_to_record",
+]

--- a/tools/federal_ingest/schema.py
+++ b/tools/federal_ingest/schema.py
@@ -1,0 +1,37 @@
+"""SQLAlchemy table metadata for federal ingestion targets."""
+from __future__ import annotations
+
+from sqlalchemy import JSON, Column, DateTime, MetaData, String, Table
+
+from tools.data_pipeline.scripts.schema import (
+    congress_bills,
+    congress_members,
+    congress_votes,
+    govinfo_downloads,
+    govinfo_packages,
+)
+
+metadata = MetaData(schema="public")
+
+govinfo_bulk_resources = Table(
+    "govinfo_bulk_resources",
+    metadata,
+    Column("resource_key", String, primary_key=True),
+    Column("collection", String, nullable=False),
+    Column("congress", String, nullable=True),
+    Column("resource_path", String, nullable=False),
+    Column("download_url", String, nullable=False),
+    Column("retrieved_at", DateTime, nullable=False),
+    Column("raw_payload", JSON, nullable=False),
+)
+
+TABLE_MAP = {
+    "congress_bills": congress_bills,
+    "congress_members": congress_members,
+    "congress_votes": congress_votes,
+    "govinfo_packages": govinfo_packages,
+    "govinfo_downloads": govinfo_downloads,
+    "govinfo_bulk_resources": govinfo_bulk_resources,
+}
+
+__all__ = ["TABLE_MAP", "govinfo_bulk_resources"]

--- a/tools/federal_ingest/storage.py
+++ b/tools/federal_ingest/storage.py
@@ -1,0 +1,65 @@
+"""Storage helpers for exporting ingestion results and downloading resources."""
+from __future__ import annotations
+
+import json
+import logging
+from datetime import date, datetime
+from pathlib import Path
+from typing import Iterable
+
+import requests
+
+from .normalization import NormalizedRecord
+
+logger = logging.getLogger(__name__)
+
+
+def _json_default(value):  # type: ignore[override]
+    if isinstance(value, (datetime, date)):
+        return value.isoformat()
+    if isinstance(value, set):
+        return list(value)
+    raise TypeError(f"Object of type {type(value)!r} is not JSON serializable")
+
+
+def export_records(export_path: Path, records: Iterable[NormalizedRecord]) -> int:
+    """Write normalized records to a JSON Lines file."""
+
+    export_path.parent.mkdir(parents=True, exist_ok=True)
+    count = 0
+    with export_path.open("w", encoding="utf-8") as handle:
+        for record in records:
+            payload = {
+                "table": record["table"],
+                "unique_columns": list(record["unique_columns"]),
+                "data": record["data"],
+            }
+            handle.write(json.dumps(payload, default=_json_default) + "\n")
+            count += 1
+    logger.info("Wrote %s records to %s", count, export_path)
+    return count
+
+
+def download_resource(url: str, destination_dir: Path, *, session: requests.Session | None = None) -> Path:
+    """Download a resource to the destination directory, returning the file path."""
+
+    destination_dir.mkdir(parents=True, exist_ok=True)
+    local_name = url.split("/")[-1]
+    target_path = destination_dir / local_name
+    if target_path.exists():
+        logger.info("Skipping existing download %s", target_path)
+        return target_path
+    sess = session or requests.Session()
+    logger.info("Downloading %s -> %s", url, target_path)
+    with sess.get(url, stream=True, timeout=60) as response:
+        response.raise_for_status()
+        with target_path.open("wb") as fh:
+            for chunk in response.iter_content(chunk_size=8192):
+                if chunk:
+                    fh.write(chunk)
+    if session is None:
+        sess.close()
+    return target_path
+
+
+__all__ = ["export_records", "download_resource"]

--- a/tools/pyproject.toml
+++ b/tools/pyproject.toml
@@ -9,6 +9,8 @@ dependencies = [
     "pydantic",
     "pydantic-settings",
     "requests",
+    "sqlalchemy",
+    "tenacity",
     "pandas",
     "numpy",
     "torch",

--- a/tools/requirements.txt
+++ b/tools/requirements.txt
@@ -1,4 +1,6 @@
 requests==2.32.3
+sqlalchemy==2.0.36
+tenacity==9.0.0
 beautifulsoup4==4.12.3
 lxml==5.2.1
 psycopg2-binary==2.9.9  # For future DB interactions


### PR DESCRIPTION
## **User description**
### **User description**
## Summary
- add a dedicated `tools/federal_ingest` package that exposes API clients and CLIs for Congress.gov, GovInfo REST, and GovInfo bulkdata sources
- provide normalization, JSON export, optional download, and PostgreSQL upsert helpers that align with the existing ingestion schema
- document environment setup and usage while declaring the additional Python dependencies required by the new tooling

## Testing
- python -m tools.federal_ingest.cli.main --help

------
https://chatgpt.com/codex/tasks/task_e_6906d015c7e0832a95818e6b6dd5fb59


___

### **PR Type**
Enhancement


___

### **Description**
- Add comprehensive federal ingestion toolkit with clients for Congress.gov, GovInfo REST API, and GovInfo bulkdata

- Implement normalization layer converting API payloads to database-friendly records with ISO timestamp serialization

- Provide CLI entrypoints for bills, members, votes, packages, downloads, and bulk resources with export and upsert capabilities

- Include database helpers for PostgreSQL upserts with conflict resolution and new `govinfo_bulk_resources` table schema

- Add storage utilities for JSON Lines export and optional resource downloads with retry support


___

### Diagram Walkthrough


```mermaid
flowchart LR
  Congress["Congress.gov API"]
  GovInfoAPI["GovInfo REST API"]
  GovInfoBulk["GovInfo Bulkdata"]
  
  Congress -- "CongressGovIngestClient" --> Normalize["Normalization Layer"]
  GovInfoAPI -- "GovInfoApiIngestClient" --> Normalize
  GovInfoBulk -- "GovInfoBulkClient" --> Normalize
  
  Normalize --> CLI["Unified CLI Entrypoint"]
  CLI --> Export["JSON Lines Export"]
  CLI --> Download["Resource Download"]
  CLI --> DB["PostgreSQL Upsert"]
```



<details> <summary><h3> File Walkthrough</h3></summary>

<table><thead><tr><th></th><th align="left">Relevant files</th></tr></thead><tbody><tr><td><strong>Enhancement</strong></td><td><details><summary>15 files</summary><table>
<tr>
  <td><strong>__init__.py</strong><dd><code>Package initialization exposing main CLI entrypoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-d96d404508f71506706993bd5dec587a8636f81406cc6102a81ef09cf46323af">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>CLI module initialization with main entrypoint</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-93eaa3a6b2deed00444759b8464acda6bb3e74844632095bdabace24dd6a9ece">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>common.py</strong><dd><code>Shared CLI helpers for logging and record handling</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-6e2da64a8ea834c1b6a76dddc1ba8ab3a2e53ce52e6bb17d349d080684ed9847">+42/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>congress_cli.py</strong><dd><code>Congress.gov API CLI with bills, members, votes commands</code>&nbsp; </dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-ca64c4b4e1c6965d4aedd11c56b860624ddb41497cef9bc189d728e824666e7a">+53/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>govinfo_api_cli.py</strong><dd><code>GovInfo REST API CLI for packages and downloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-2622bb509753e7e2cbf8e391732ae357a8f1c1fb98949d55d634873af02f4883">+51/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>govinfo_bulk_cli.py</strong><dd><code>GovInfo bulkdata crawler CLI with optional downloads</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-e5f18eb67891260075243f8c6eacab0f09233a7e47ffb309cae2c9fe8e6e1565">+53/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>main.py</strong><dd><code>Unified entrypoint routing to source-specific CLIs</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-29ecb31539caf584e3f7d1afede03503b3620590f4b8e8622650291101f2fd39">+38/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>__init__.py</strong><dd><code>Client factory exports for all three data sources</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-8f62b2ec27eb08a465b26b4cca797b42de4d51ae0f134cb6056cf05c1ffca690">+11/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>congress.py</strong><dd><code>Congress.gov client extending base with normalized iterators</code></dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-4694999525eb7682f489617b07f8edb91cfc5f5d759fff48189bcd78130e9ef1">+60/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>govinfo_api.py</strong><dd><code>GovInfo REST API client with normalized package and download streams</code></dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-03a3ddd3c78e969dfcd086bf01bb1c727ab0500f41d05e215c09be6bfd65f058">+41/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>govinfo_bulk.py</strong><dd><code>GovInfo bulkdata directory crawler with HTML parsing</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-1eda66d5b3974b4abf28a7d8a73945fdf30ae105b7687e538e3069242771eeb2">+112/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>db.py</strong><dd><code>Database engine creation and upsert helpers with conflict resolution</code></dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-6675c2f216783c7304c15831b38655dffda8b530c9f43d9c53192d81b5b70db5">+67/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>normalization.py</strong><dd><code>Payload normalization with datetime serialization and record typing</code></dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-aa76bedc8d85258403e84e1b0caa7682996f1077323652cbf3a1467e38a85b7e">+132/-0</a>&nbsp; </td>

</tr>

<tr>
  <td><strong>schema.py</strong><dd><code>SQLAlchemy table metadata mapping for all ingestion targets</code></dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-f93e3ec7c03734e4f391874f1e71d8b5e15d4683fa39e45270eaa581cb72ff41">+37/-0</a>&nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>storage.py</strong><dd><code>JSON Lines export and resource download utilities</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-786e3cd9d3fa3fc3ef473edc16ad8387b6ffea9331014fec0866a84a86941ba4">+65/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Configuration changes</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>config.py</strong><dd><code>Configuration settings loader from environment variables</code>&nbsp; </dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-8fc7c75c702c63d597a455bbbe3d2fb7328bb6dcbde7cb762e3af574cc25ce56">+37/-0</a>&nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Documentation</strong></td><td><details><summary>1 files</summary><table>
<tr>
  <td><strong>README.md</strong><dd><code>Comprehensive documentation for setup, usage, and configuration</code></dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-efff3fbddc8edc3c63f07989daf9823c1f4f08cbbe4b918489faa4c193c8ce2e">+138/-0</a>&nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Dependencies</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>pyproject.toml</strong><dd><code>Add sqlalchemy and tenacity dependencies</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-34e90ee5f36843fb20583311fd7c4b5323270afe4277793801cad4c54e8abb67">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>requirements.txt</strong><dd><code>Add sqlalchemy and tenacity package versions</code>&nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; &nbsp; </dd></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-1ed4efd531f910f92b0dd60fadf0be32ec199b1e1f75fe71c37cdcc567938091">+2/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr><tr><td><strong>Additional files</strong></td><td><details><summary>2 files</summary><table>
<tr>
  <td><strong>DIFF_20251102_033600.md</strong></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-2c3ee6a93d5ec8600201c49170147e80ad1aeb9599c5bec1e40c4551d84637af">+7/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>

<tr>
  <td><strong>RECOMMENDATIONS_20251102_033612.md</strong></td>
  <td><a href="https://github.com/cbwinslow/OpenLegislation-local-dev/pull/53/files#diff-7564830fdf4459ddf60d92dcd99f4f14d2c74ee3f2e9e358d1e100d4cb029ab7">+5/-0</a>&nbsp; &nbsp; &nbsp; </td>

</tr>
</table></details></td></tr></tr></tbody></table>

</details>

___


___

## **CodeAnt-AI Description**
**Add federal ingestion toolkit with CLI, JSONL export, downloads, and Postgres upsert**

### What Changed
- Added a unified command-line toolkit to ingest data from Congress.gov, GovInfo REST, and GovInfo bulkdata with resource-specific commands (bills, members, votes, packages, downloads, bulk resources).
- Clients emit normalized records that serialize dates as ISO timestamps and keep original payloads for auditability.
- New export capability writes normalized results to JSON Lines files; bulk resources can be optionally downloaded to a directory (downloads skip already-downloaded files).
- Optional persistence into PostgreSQL is supported: records are grouped by target table and upserted with conflict resolution; a per-run database URL override is available.
- Added a manifest target for GovInfo bulk resources so crawled resources can be tracked and stored in the database.
- CLI includes logging verbosity flag and requires API credentials via environment variables (CONGRESS_GOV_API_KEY, GOVINFO_API_KEY); FEDERAL_INGEST_DATABASE_URL can override DB target.
- Tooling declares new runtime dependencies needed for the ingestion workflow.

### Impact
`✅ Command-line import for Congress.gov and GovInfo`
`✅ Exportable JSONL manifests with ISO timestamps`
`✅ Optional PostgreSQL upserts for automated persistence`
<details>
<summary><strong>💡 Usage Guide</strong></summary>

### Checking Your Pull Request
Every time you make a pull request, our system automatically looks through it. We check for security issues, mistakes in how you're setting up your infrastructure, and common code problems. We do this to make sure your changes are solid and won't cause any trouble later.

### Talking to CodeAnt AI
Got a question or need a hand with something in your pull request? You can easily get in touch with CodeAnt AI right here. Just type the following in a comment on your pull request, and replace "Your question here" with whatever you want to ask:
<pre>
<code>@codeant-ai ask: Your question here</code>
</pre>
This lets you have a chat with CodeAnt AI about your pull request, making it easier to understand and improve your code.

#### Example
<pre>
<code>@codeant-ai ask: Can you suggest a safer alternative to storing this secret?</code>
</pre>

### Preserve Org Learnings with CodeAnt
You can record team preferences so CodeAnt AI applies them in future reviews. Reply directly to the specific CodeAnt AI suggestion (in the same thread) and replace "Your feedback here" with your input:
<pre>
<code>@codeant-ai: Your feedback here</code>
</pre>
This helps CodeAnt AI learn and adapt to your team's coding style and standards.

#### Example
<pre>
<code>@codeant-ai: Do not flag unused imports.</code>
</pre>

### Retrigger review
Ask CodeAnt AI to review the PR again, by typing:
<pre>
<code>@codeant-ai: review</code>
</pre>

### Check Your Repository Health
To analyze the health of your code repository, visit our dashboard at [https://app.codeant.ai](https://app.codeant.ai). This tool helps you identify potential issues and areas for improvement in your codebase, ensuring your repository maintains high standards of code health.

</details>


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Introduced Federal Ingestion Toolkit with command-line interface for importing legislative data from Congress.gov and GovInfo.
  * Support for multiple data sources: Congress.gov REST API, GovInfo REST API, and GovInfo bulk data.
  * Export ingested records to JSON format and persist to database with upsert functionality.
  * Optional download capability for bulk resources.

* **Dependencies**
  * Added SQLAlchemy and tenacity as project dependencies.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->